### PR TITLE
feat: add lemon import endpoint

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -85,6 +85,7 @@ from open_webui.routers import (
     tools,
     users,
     utils,
+    custom,
     scim,
 )
 
@@ -1233,6 +1234,7 @@ app.include_router(functions.router, prefix="/api/v1/functions", tags=["function
 app.include_router(
     evaluations.router, prefix="/api/v1/evaluations", tags=["evaluations"]
 )
+app.include_router(custom.router, prefix="/api/custom", tags=["custom"])
 app.include_router(utils.router, prefix="/api/v1/utils", tags=["utils"])
 
 # SCIM 2.0 API for identity management

--- a/backend/open_webui/routers/custom.py
+++ b/backend/open_webui/routers/custom.py
@@ -1,0 +1,23 @@
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+from typing import List
+
+from open_webui.models.users import Users
+from open_webui.models.groups import Groups
+
+router = APIRouter()
+
+
+class UserImportRequest(BaseModel):
+    email: str
+    groups: List[str]
+
+
+@router.post("/lemon-import")
+async def lemon_import(users: List[UserImportRequest]):
+    for user in users:
+        existing_user = Users.get_user_by_email(user.email)
+        if not existing_user:
+            raise HTTPException(status_code=404, detail=f"User {user.email} not found")
+        Groups.sync_groups_by_group_names(existing_user.id, user.groups)
+    return {"status": "ok", "imported": len(users)}


### PR DESCRIPTION
## Summary
- add custom lemon-import API endpoint to update user groups
- register new custom router with FastAPI app

## Testing
- `python -m black backend/open_webui/routers/custom.py backend/open_webui/main.py`
- `pytest backend/open_webui/test -q` *(fails: ModuleNotFoundError: No module named 'test.util')*
- `pip install moto --quiet`
- `PYTHONPATH=backend:backend/open_webui pytest backend/open_webui/test -q` *(fails: peewee.OperationalError: unable to open database file)*

------
https://chatgpt.com/codex/tasks/task_e_68a5fa8fe5888326aab61a105b63bd52