### PR TITLE
Add migration runner script

### DIFF
--- a/backend/open_webui/run_migrations.py
+++ b/backend/open_webui/run_migrations.py
@@ -1,0 +1,4 @@
+from open_webui.utils.alembic_utils import run_migrations
+
+if __name__ == "__main__":
+    run_migrations()

--- a/backend/open_webui/utils/alembic_utils.py
+++ b/backend/open_webui/utils/alembic_utils.py
@@ -1,0 +1,18 @@
+from open_webui.env import OPEN_WEBUI_DIR, log
+
+
+def run_migrations() -> None:
+    """Run database migrations using Alembic."""
+    log.info("Running migrations")
+    try:
+        from alembic import command
+        from alembic.config import Config
+
+        alembic_cfg = Config(OPEN_WEBUI_DIR / "alembic.ini")
+
+        migrations_path = OPEN_WEBUI_DIR / "migrations"
+        alembic_cfg.set_main_option("script_location", str(migrations_path))
+
+        command.upgrade(alembic_cfg, "head")
+    except Exception as e:
+        log.exception(f"Error running migrations: {e}")


### PR DESCRIPTION
## Summary
- add `run_migrations.py` entry point to execute database migrations
- provide Alembic utility to run migrations from Open WebUI backend

## Testing
- `PYTHONPATH=backend python3 backend/open_webui/run_migrations.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'test.util')*


------
https://chatgpt.com/codex/tasks/task_e_68a6144fbe3083269340573e7fbd76d9