### PR TITLE
feat: add sync users endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,6 @@ FORWARDED_ALLOW_IPS='*'
 SCARF_NO_ANALYTICS=true
 DO_NOT_TRACK=true
 ANONYMIZED_TELEMETRY=false
+
+# Token used for the /api/sync-users endpoint
+SYNC_USERS_TOKEN=""

--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -453,6 +453,12 @@ SCIM_ENABLED = os.environ.get("SCIM_ENABLED", "False").lower() == "true"
 SCIM_TOKEN = os.environ.get("SCIM_TOKEN", "")
 
 ####################################
+# Internal API Token
+####################################
+
+SYNC_USERS_TOKEN = os.environ.get("SYNC_USERS_TOKEN", "")
+
+####################################
 # LICENSE_KEY
 ####################################
 

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -84,6 +84,7 @@ from open_webui.routers import (
     evaluations,
     tools,
     users,
+    sync_users,
     utils,
     custom,
     scim,
@@ -424,6 +425,7 @@ from open_webui.env import (
     # SCIM
     SCIM_ENABLED,
     SCIM_TOKEN,
+    SYNC_USERS_TOKEN,
     ENABLE_COMPRESSION_MIDDLEWARE,
     ENABLE_WEBSOCKET_SUPPORT,
     BYPASS_MODEL_ACCESS_CONTROL,
@@ -669,6 +671,7 @@ app.state.config.ENABLE_DIRECT_CONNECTIONS = ENABLE_DIRECT_CONNECTIONS
 
 app.state.SCIM_ENABLED = SCIM_ENABLED
 app.state.SCIM_TOKEN = SCIM_TOKEN
+app.state.SYNC_USERS_TOKEN = SYNC_USERS_TOKEN
 
 ########################################
 #
@@ -1219,6 +1222,7 @@ app.include_router(configs.router, prefix="/api/v1/configs", tags=["configs"])
 
 app.include_router(auths.router, prefix="/api/v1/auths", tags=["auths"])
 app.include_router(users.router, prefix="/api/v1/users", tags=["users"])
+app.include_router(sync_users.router, prefix="/api", tags=["sync-users"])
 
 
 app.include_router(channels.router, prefix="/api/v1/channels", tags=["channels"])

--- a/backend/open_webui/models/groups.py
+++ b/backend/open_webui/models/groups.py
@@ -149,6 +149,18 @@ class GroupTable:
         except Exception:
             return None
 
+    def get_group_by_name(self, name: str) -> Optional[GroupModel]:
+        try:
+            with get_db() as db:
+                group = (
+                    db.query(Group)
+                    .filter(func.lower(Group.name) == name.lower())
+                    .first()
+                )
+                return GroupModel.model_validate(group) if group else None
+        except Exception:
+            return None
+
     def get_group_user_ids_by_id(self, id: str) -> Optional[str]:
         group = self.get_group_by_id(id)
         if group:

--- a/backend/open_webui/routers/sync_users.py
+++ b/backend/open_webui/routers/sync_users.py
@@ -1,0 +1,81 @@
+import secrets
+from typing import Any, Dict, Optional
+
+from fastapi import APIRouter, Header, HTTPException, Request, status
+from pydantic import BaseModel, ValidationError
+
+from open_webui.models.users import Users
+from open_webui.models.auths import Auths
+from open_webui.models.groups import Groups
+from open_webui.utils.auth import get_password_hash
+
+router = APIRouter()
+
+
+class SyncUser(BaseModel):
+    name: str
+    email: str
+    password: Optional[str] = None
+    role: str = "user"
+    group: Optional[str] = None
+
+
+@router.post("/sync-users")
+async def sync_users(
+    request: Request, data: Dict[str, Any], authorization: Optional[str] = Header(None)
+):
+    token = getattr(request.app.state, "SYNC_USERS_TOKEN", None)
+    if not authorization or not authorization.lower().startswith("bearer "):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing authorization"
+        )
+    if not token or authorization.split(" ", 1)[1] != token:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token"
+        )
+
+    users_payload = data.get("users") if isinstance(data, dict) else data
+    if not isinstance(users_payload, list):
+        raise HTTPException(status_code=400, detail="Invalid payload")
+
+    results = []
+    for raw_user in users_payload:
+        try:
+            user_data = SyncUser.model_validate(raw_user)
+            existing = Users.get_user_by_email(user_data.email)
+            if not existing:
+                password = user_data.password or secrets.token_urlsafe(12)
+                hashed = get_password_hash(password)
+                created = Auths.insert_new_auth(
+                    email=user_data.email,
+                    password=hashed,
+                    name=user_data.name,
+                    role=user_data.role,
+                )
+                user_id = created.id if created else None
+                status_msg = "created"
+            else:
+                update = {
+                    "name": user_data.name,
+                    "email": user_data.email,
+                    "role": user_data.role,
+                }
+                Users.update_user_by_id(existing.id, update)
+                if user_data.password:
+                    Auths.update_user_password_by_id(
+                        existing.id, get_password_hash(user_data.password)
+                    )
+                user_id = existing.id
+                status_msg = "updated"
+
+            if user_data.group and user_id:
+                group = Groups.get_group_by_name(user_data.group)
+                if group:
+                    Groups.add_users_to_group(group.id, [user_id])
+
+            results.append({"email": user_data.email, "status": status_msg, "success": True})
+        except ValidationError as e:
+            results.append({"email": raw_user.get("email"), "success": False, "error": e.errors()})
+        except Exception as e:  # pragma: no cover - log unexpected
+            results.append({"email": getattr(user_data, "email", None), "success": False, "error": str(e)})
+    return {"results": results}

--- a/backend/open_webui/test/apps/webui/routers/test_sync_users.py
+++ b/backend/open_webui/test/apps/webui/routers/test_sync_users.py
@@ -1,0 +1,48 @@
+from test.util.abstract_integration_test import AbstractPostgresTest
+from open_webui.models.users import Users
+from open_webui.models.groups import Groups, GroupForm
+import os
+
+
+class TestSyncUsers(AbstractPostgresTest):
+    BASE_PATH = "/api/sync-users"
+
+    @classmethod
+    def setup_class(cls):
+        os.environ["SYNC_USERS_TOKEN"] = "testtoken"
+        super().setup_class()
+
+    def setup_method(self):
+        super().setup_method()
+        Users.insert_new_user(
+            id="owner",
+            name="owner",
+            email="owner@example.com",
+            profile_image_url="/user.png",
+            role="user",
+        )
+        Groups.insert_new_group("owner", GroupForm(name="Student", description="d"))
+
+    def test_sync_user_creation(self):
+        payload = {
+            "users": [
+                {
+                    "name": "Jane Doe",
+                    "email": "jane@example.com",
+                    "role": "user",
+                    "group": "Student",
+                }
+            ]
+        }
+        response = self.fast_api_client.post(
+            self.create_url(""),
+            json=payload,
+            headers={"Authorization": "Bearer testtoken"},
+        )
+        assert response.status_code == 200
+        data = response.json()["results"][0]
+        assert data["status"] == "created"
+        user = Users.get_user_by_email("jane@example.com")
+        assert user is not None
+        group = Groups.get_group_by_name("Student")
+        assert user.id in group.user_ids


### PR DESCRIPTION
## Summary
- allow syncing users with bearer token via `/api/sync-users`
- add internal token configuration and group lookup helper
- test coverage for syncing users to groups

## Testing
- `PYTHONPATH=backend:backend/open_webui python -m pytest backend/open_webui/test/apps/webui/routers/test_sync_users.py -q` *(fails: Error while fetching server API version: ('Connection aborted.', FileNotFoundError(2, 'No such file or directory')))*

------
https://chatgpt.com/codex/tasks/task_e_68a76f854a708326a36cab034774e902