### PR TITLE
chore: add debug output for OWUI auth token

### DIFF
--- a/backend/open_webui/routers/sync_users.py
+++ b/backend/open_webui/routers/sync_users.py
@@ -24,8 +24,9 @@ class SyncUser(BaseModel):
 async def sync_users(
     request: Request, data: Dict[str, Any], authorization: Optional[str] = Header(None)
 ):
-    token = getattr(request.app.state, "OWUI_AUTH_TOKEN", None)
-    if not authorization or authorization != token:
+    OWUI_AUTH_TOKEN = getattr(request.app.state, "OWUI_AUTH_TOKEN", None)
+    print("🧪 OWUI sees token as:", repr(OWUI_AUTH_TOKEN))
+    if not authorization or authorization != OWUI_AUTH_TOKEN:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token"
         )

--- a/backend/open_webui/routes/api/sync_users.py
+++ b/backend/open_webui/routes/api/sync_users.py
@@ -13,6 +13,7 @@ router = APIRouter()
 SUPABASE_URL = os.getenv("SUPABASE_URL")
 SUPABASE_API_KEY = os.getenv("SUPABASE_API_KEY")
 OWUI_AUTH_TOKEN = os.getenv("OWUI_AUTH_TOKEN")
+print("🧪 OWUI sees token as:", repr(OWUI_AUTH_TOKEN))
 
 PLAN_GROUP_MAP = {
     "free": "1",


### PR DESCRIPTION
## Summary
- print auth token during sync-users calls for debugging

## Testing
- `pre-commit run --files backend/open_webui/routers/sync_users.py backend/open_webui/routes/api/sync_users.py` *(fails: InvalidConfigError: .pre-commit-config.yaml is not a file)*
- `PYTHONPATH=backend:backend/open_webui pytest backend/open_webui/test/apps/webui/routers/test_sync_users.py -q` *(fails: DockerException: Error while fetching server API version)*

------
https://chatgpt.com/codex/tasks/task_e_68a79754c6e883269b04636ac2484462