### PR TITLE
Move Supabase auth middleware after session setup

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -1157,8 +1157,6 @@ if ENABLE_COMPRESSION_MIDDLEWARE:
 app.add_middleware(RedirectMiddleware)
 app.add_middleware(SecurityHeadersMiddleware)
 app.add_middleware(AuthProxyMiddleware)
-# Add before SessionMiddleware (declared later) so it runs after session setup
-app.add_middleware(SupabaseAuthMiddleware)
 
 
 @app.middleware("http")
@@ -1820,6 +1818,8 @@ if len(OAUTH_PROVIDERS) > 0:
         same_site=WEBUI_SESSION_COOKIE_SAME_SITE,
         https_only=WEBUI_SESSION_COOKIE_SECURE,
     )
+
+app.add_middleware(SupabaseAuthMiddleware)
 
 
 @app.get("/oauth/{provider}/login")


### PR DESCRIPTION
## Summary
- ensure SupabaseAuthMiddleware is added after SessionMiddleware initialization

## Testing
- `pylint backend/open_webui/main.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'open_webui')*

------
https://chatgpt.com/codex/tasks/task_e_68a8ef3b82dc832693b0f8330174942f