### PR TITLE
Ensure Supabase session is set before auth proxy

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -1156,6 +1156,7 @@ if ENABLE_COMPRESSION_MIDDLEWARE:
 
 app.add_middleware(RedirectMiddleware)
 app.add_middleware(SecurityHeadersMiddleware)
+app.add_middleware(SupabaseAuthMiddleware)
 app.add_middleware(AuthProxyMiddleware)
 
 
@@ -1818,8 +1819,6 @@ if len(OAUTH_PROVIDERS) > 0:
         same_site=WEBUI_SESSION_COOKIE_SAME_SITE,
         https_only=WEBUI_SESSION_COOKIE_SECURE,
     )
-
-app.add_middleware(SupabaseAuthMiddleware)
 
 
 @app.get("/oauth/{provider}/login")

--- a/backend/open_webui/middleware/supabase_auth.py
+++ b/backend/open_webui/middleware/supabase_auth.py
@@ -102,6 +102,14 @@ class SupabaseAuthMiddleware(BaseHTTPMiddleware):
         if not claims:
             return await call_next(request)
 
+        # Inject claims as a mock session so downstream middlewares work
+        scope["session"] = {
+            "user_id": claims.get("sub"),
+            "email": claims.get("email"),
+            "provider": claims.get("app_metadata", {}).get("provider", "email"),
+            "role": claims.get("role", "authenticated"),
+        }
+
         email = (claims.get("email") or "").strip().lower()
         if not email:
             return await call_next(request)


### PR DESCRIPTION
## Summary
- Inject session details from Supabase JWT into middleware scope
- Register SupabaseAuthMiddleware ahead of AuthProxyMiddleware

## Testing
- `pytest backend/open_webui/test -q` *(fails: ModuleNotFoundError: No module named 'test.util')*


------
https://chatgpt.com/codex/tasks/task_e_68a8f0bfa9c083268ad0ea4c1905ed20