### PR TITLE
Fix Supabase auth session injection

### DIFF
--- a/backend/open_webui/middleware/supabase_auth.py
+++ b/backend/open_webui/middleware/supabase_auth.py
@@ -103,7 +103,7 @@ class SupabaseAuthMiddleware(BaseHTTPMiddleware):
             return await call_next(request)
 
         # Inject claims as a mock session so downstream middlewares work
-        scope["session"] = {
+        request.scope["session"] = {
             "user_id": claims.get("sub"),
             "email": claims.get("email"),
             "provider": claims.get("app_metadata", {}).get("provider", "email"),


### PR DESCRIPTION
## Summary
- ensure Supabase auth middleware writes mock session directly into `request.scope`

## Testing
- `pytest backend/open_webui/test -q` *(fails: ModuleNotFoundError: No module named 'test.util')*

------
https://chatgpt.com/codex/tasks/task_e_68a8f24a2d748326b338d2819574a551