### PR TITLE
fix: always log session state after middleware

### DIFF
--- a/backend/open_webui/middleware/supabase_auth.py
+++ b/backend/open_webui/middleware/supabase_auth.py
@@ -97,8 +97,11 @@ class SupabaseAuthMiddleware(BaseHTTPMiddleware):
         scope = getattr(request, "scope", {}) or {}
         sess = scope.get("session")
         if isinstance(sess, dict) and sess.get("user_id"):
+            log.warning(f"Session already exists, skipping injection: {sess}")
             response = await call_next(request)
-            log.warning(f"Final session state: {request.scope.get('session')}")
+            log.warning(
+                f"Final session state (pre-existing): {request.scope.get('session')}"
+            )
             return response
 
         token = _extract_bearer_token(request)

--- a/backend/open_webui/utils/auth.py
+++ b/backend/open_webui/utils/auth.py
@@ -211,8 +211,9 @@ def get_current_user(
     response: Response,
     background_tasks: BackgroundTasks,
     auth_token: HTTPAuthorizationCredentials = Depends(bearer_security),
-):
+): 
     scope = getattr(request, "scope", {}) or {}
+    log.warning(f"GET_CURRENT_USER sees session: {scope.get('session')}")
     session_user_id = None
     if isinstance(scope, dict):
         sess = scope.get("session")


### PR DESCRIPTION
## Summary
- ensure SupabaseAuthMiddleware logs when skipping session injection
- add diagnostic logging for get_current_user to view session contents

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'test.util')*


------
https://chatgpt.com/codex/tasks/task_e_68a8f5a101e88326add00acd3b06fcfb