### PR TITLE
Allow disabling PDF image extraction by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,17 @@ If you are running Prosper Chat in an offline environment, you can set the `HF_H
 export HF_HUB_OFFLINE=1
 ```
 
+### PDF Image Extraction
+
+`PDF_EXTRACT_IMAGES` controls whether images are pulled from PDF documents during
+ingestion. This can improve OCR accuracy for image-heavy PDFs but slows
+processing and increases memory use. The flag defaults to `false` for better
+performance and can be enabled via the UI or CLI:
+
+```bash
+export PDF_EXTRACT_IMAGES=true
+```
+
 ## What's Next? 🌟
 
 Discover upcoming features on our roadmap in the [Prosper Chat Documentation](https://docs.openwebui.com/roadmap/).

--- a/backend/open_webui/__init__.py
+++ b/backend/open_webui/__init__.py
@@ -34,8 +34,15 @@ def main(
 def serve(
     host: str = "0.0.0.0",
     port: int = 8080,
+    pdf_extract_images: Annotated[
+        bool,
+        typer.Option(
+            help="Extract images from PDFs during ingestion (slower but more accurate)",
+        ),
+    ] = False,
 ):
     os.environ["FROM_INIT_PY"] = "true"
+    os.environ["PDF_EXTRACT_IMAGES"] = str(pdf_extract_images).lower()
     if os.getenv("WEBUI_SECRET_KEY") is None:
         typer.echo(
             "Loading WEBUI_SECRET_KEY from file, not provided as an environment variable."

--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -2342,10 +2342,12 @@ RAG_EMBEDDING_ENGINE = PersistentConfig(
     os.environ.get("RAG_EMBEDDING_ENGINE", ""),
 )
 
+# Extracting images from PDFs can improve OCR results but may significantly slow
+# ingestion. Disabled by default for performance.
 PDF_EXTRACT_IMAGES = PersistentConfig(
     "PDF_EXTRACT_IMAGES",
     "rag.pdf_extract_images",
-    os.environ.get("PDF_EXTRACT_IMAGES", "False").lower() == "true",
+    os.environ.get("PDF_EXTRACT_IMAGES", "false").lower() == "true",
 )
 
 RAG_EMBEDDING_MODEL = PersistentConfig(

--- a/backend/open_webui/retrieval/loaders/main.py
+++ b/backend/open_webui/retrieval/loaders/main.py
@@ -254,7 +254,7 @@ class Loader:
                     url=self.kwargs.get("TIKA_SERVER_URL"),
                     file_path=file_path,
                     mime_type=file_content_type,
-                    extract_images=self.kwargs.get("PDF_EXTRACT_IMAGES"),
+                    extract_images=self.kwargs.get("PDF_EXTRACT_IMAGES", False),
                 )
         elif (
             self.engine == "datalab_marker"
@@ -366,7 +366,7 @@ class Loader:
         else:
             if file_ext == "pdf":
                 loader = PyPDFLoader(
-                    file_path, extract_images=self.kwargs.get("PDF_EXTRACT_IMAGES")
+                    file_path, extract_images=self.kwargs.get("PDF_EXTRACT_IMAGES", False)
                 )
             elif file_ext == "csv":
                 loader = CSVLoader(file_path, autodetect_encoding=True)


### PR DESCRIPTION
## Summary
- disable PDF image extraction by default for better performance
- expose `--pdf-extract-images` CLI flag
- document PDF image extraction trade-offs

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'open_webui')*
- `npm run test:frontend` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8d5ec8608326a587cf54255096b0