### PR TITLE
Process file before raising FILE_NOT_PROCESSED in knowledge router

### DIFF
--- a/backend/open_webui/routers/knowledge.py
+++ b/backend/open_webui/routers/knowledge.py
@@ -363,24 +363,37 @@ async def add_file_to_knowledge_by_id(
             detail=ERROR_MESSAGES.NOT_FOUND,
         )
     if not file.data:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=ERROR_MESSAGES.FILE_NOT_PROCESSED,
-        )
-
-    # Add content to the vector database
-    try:
-        await process_file(
-            request,
-            ProcessFileForm(file_id=form_data.file_id, collection_name=id),
-            user=user,
-        )
-    except Exception as e:
-        log.debug(e)
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=str(e),
-        )
+        try:
+            await process_file(
+                request,
+                ProcessFileForm(file_id=form_data.file_id, collection_name=id),
+                user=user,
+            )
+            file = Files.get_file_by_id(form_data.file_id)
+        except Exception as e:
+            log.debug(e)
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=str(e),
+            )
+        if not file.data:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=ERROR_MESSAGES.FILE_NOT_PROCESSED,
+            )
+    else:
+        try:
+            await process_file(
+                request,
+                ProcessFileForm(file_id=form_data.file_id, collection_name=id),
+                user=user,
+            )
+        except Exception as e:
+            log.debug(e)
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=str(e),
+            )
 
     if knowledge:
         data = knowledge.data or {}


### PR DESCRIPTION
## Summary
- try processing knowledge file when no extracted data exists
- raise FILE_NOT_PROCESSED only if content extraction still fails

## Testing
- `pytest backend/open_webui/test -q` *(fails: No module named 'test.util')*

------
https://chatgpt.com/codex/tasks/task_e_68aca50a46fc8326858e2fbe78dfcecb