### PR TITLE
Disable unnecessary OCR and Datalab Marker settings

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -50,7 +50,6 @@ logging.getLogger("uvicorn.access").addFilter(EndpointFilter())
 ####################################
 
 
-
 # Ensure the database schema is up to date
 run_migrations()
 
@@ -2107,44 +2106,43 @@ DATALAB_MARKER_ADDITIONAL_CONFIG = PersistentConfig(
 DATALAB_MARKER_USE_LLM = PersistentConfig(
     "DATALAB_MARKER_USE_LLM",
     "rag.DATALAB_MARKER_USE_LLM",
-    os.environ.get("DATALAB_MARKER_USE_LLM", "false").lower() == "true",
+    False,
 )
 
 DATALAB_MARKER_SKIP_CACHE = PersistentConfig(
     "DATALAB_MARKER_SKIP_CACHE",
     "rag.datalab_marker_skip_cache",
-    os.environ.get("DATALAB_MARKER_SKIP_CACHE", "false").lower() == "true",
+    False,
 )
 
 DATALAB_MARKER_FORCE_OCR = PersistentConfig(
     "DATALAB_MARKER_FORCE_OCR",
     "rag.datalab_marker_force_ocr",
-    os.environ.get("DATALAB_MARKER_FORCE_OCR", "false").lower() == "true",
+    False,
 )
 
 DATALAB_MARKER_PAGINATE = PersistentConfig(
     "DATALAB_MARKER_PAGINATE",
     "rag.datalab_marker_paginate",
-    os.environ.get("DATALAB_MARKER_PAGINATE", "false").lower() == "true",
+    False,
 )
 
 DATALAB_MARKER_STRIP_EXISTING_OCR = PersistentConfig(
     "DATALAB_MARKER_STRIP_EXISTING_OCR",
     "rag.datalab_marker_strip_existing_ocr",
-    os.environ.get("DATALAB_MARKER_STRIP_EXISTING_OCR", "false").lower() == "true",
+    False,
 )
 
 DATALAB_MARKER_DISABLE_IMAGE_EXTRACTION = PersistentConfig(
     "DATALAB_MARKER_DISABLE_IMAGE_EXTRACTION",
     "rag.datalab_marker_disable_image_extraction",
-    os.environ.get("DATALAB_MARKER_DISABLE_IMAGE_EXTRACTION", "false").lower()
-    == "true",
+    False,
 )
 
 DATALAB_MARKER_FORMAT_LINES = PersistentConfig(
     "DATALAB_MARKER_FORMAT_LINES",
     "rag.datalab_marker_format_lines",
-    os.environ.get("DATALAB_MARKER_FORMAT_LINES", "false").lower() == "true",
+    False,
 )
 
 DATALAB_MARKER_OUTPUT_FORMAT = PersistentConfig(
@@ -2180,52 +2178,37 @@ DOCLING_SERVER_URL = PersistentConfig(
 DOCLING_OCR_ENGINE = PersistentConfig(
     "DOCLING_OCR_ENGINE",
     "rag.docling_ocr_engine",
-    os.getenv("DOCLING_OCR_ENGINE", "tesseract"),
+    "",
 )
 
 DOCLING_OCR_LANG = PersistentConfig(
     "DOCLING_OCR_LANG",
     "rag.docling_ocr_lang",
-    os.getenv("DOCLING_OCR_LANG", "eng,fra,deu,spa"),
+    "",
 )
 
 DOCLING_DO_PICTURE_DESCRIPTION = PersistentConfig(
     "DOCLING_DO_PICTURE_DESCRIPTION",
     "rag.docling_do_picture_description",
-    os.getenv("DOCLING_DO_PICTURE_DESCRIPTION", "False").lower() == "true",
+    False,
 )
 
 DOCLING_PICTURE_DESCRIPTION_MODE = PersistentConfig(
     "DOCLING_PICTURE_DESCRIPTION_MODE",
     "rag.docling_picture_description_mode",
-    os.getenv("DOCLING_PICTURE_DESCRIPTION_MODE", ""),
+    "",
 )
-
-
-docling_picture_description_local = os.getenv("DOCLING_PICTURE_DESCRIPTION_LOCAL", "")
-try:
-    docling_picture_description_local = json.loads(docling_picture_description_local)
-except json.JSONDecodeError:
-    docling_picture_description_local = {}
-
 
 DOCLING_PICTURE_DESCRIPTION_LOCAL = PersistentConfig(
     "DOCLING_PICTURE_DESCRIPTION_LOCAL",
     "rag.docling_picture_description_local",
-    docling_picture_description_local,
+    {},
 )
-
-docling_picture_description_api = os.getenv("DOCLING_PICTURE_DESCRIPTION_API", "")
-try:
-    docling_picture_description_api = json.loads(docling_picture_description_api)
-except json.JSONDecodeError:
-    docling_picture_description_api = {}
-
 
 DOCLING_PICTURE_DESCRIPTION_API = PersistentConfig(
     "DOCLING_PICTURE_DESCRIPTION_API",
     "rag.docling_picture_description_api",
-    docling_picture_description_api,
+    {},
 )
 
 
@@ -2353,7 +2336,7 @@ RAG_EMBEDDING_ENGINE = PersistentConfig(
 PDF_EXTRACT_IMAGES = PersistentConfig(
     "PDF_EXTRACT_IMAGES",
     "rag.pdf_extract_images",
-    os.environ.get("PDF_EXTRACT_IMAGES", "false").lower() == "true",
+    False,
 )
 
 RAG_EMBEDDING_MODEL = PersistentConfig(

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -1415,27 +1415,27 @@ def _process_file_sync(
                     DATALAB_MARKER_API_KEY=request.app.state.config.DATALAB_MARKER_API_KEY,
                     DATALAB_MARKER_API_BASE_URL=request.app.state.config.DATALAB_MARKER_API_BASE_URL,
                     DATALAB_MARKER_ADDITIONAL_CONFIG=request.app.state.config.DATALAB_MARKER_ADDITIONAL_CONFIG,
-                    DATALAB_MARKER_SKIP_CACHE=request.app.state.config.DATALAB_MARKER_SKIP_CACHE,
-                    DATALAB_MARKER_FORCE_OCR=request.app.state.config.DATALAB_MARKER_FORCE_OCR,
-                    DATALAB_MARKER_PAGINATE=request.app.state.config.DATALAB_MARKER_PAGINATE,
-                    DATALAB_MARKER_STRIP_EXISTING_OCR=request.app.state.config.DATALAB_MARKER_STRIP_EXISTING_OCR,
-                    DATALAB_MARKER_DISABLE_IMAGE_EXTRACTION=request.app.state.config.DATALAB_MARKER_DISABLE_IMAGE_EXTRACTION,
-                    DATALAB_MARKER_FORMAT_LINES=request.app.state.config.DATALAB_MARKER_FORMAT_LINES,
-                    DATALAB_MARKER_USE_LLM=request.app.state.config.DATALAB_MARKER_USE_LLM,
+                    DATALAB_MARKER_SKIP_CACHE=False,
+                    DATALAB_MARKER_FORCE_OCR=False,
+                    DATALAB_MARKER_PAGINATE=False,
+                    DATALAB_MARKER_STRIP_EXISTING_OCR=False,
+                    DATALAB_MARKER_DISABLE_IMAGE_EXTRACTION=False,
+                    DATALAB_MARKER_FORMAT_LINES=False,
+                    DATALAB_MARKER_USE_LLM=False,
                     DATALAB_MARKER_OUTPUT_FORMAT=request.app.state.config.DATALAB_MARKER_OUTPUT_FORMAT,
                     EXTERNAL_DOCUMENT_LOADER_URL=request.app.state.config.EXTERNAL_DOCUMENT_LOADER_URL,
                     EXTERNAL_DOCUMENT_LOADER_API_KEY=request.app.state.config.EXTERNAL_DOCUMENT_LOADER_API_KEY,
                     TIKA_SERVER_URL=request.app.state.config.TIKA_SERVER_URL,
                     DOCLING_SERVER_URL=request.app.state.config.DOCLING_SERVER_URL,
                     DOCLING_PARAMS={
-                        "ocr_engine": request.app.state.config.DOCLING_OCR_ENGINE,
-                        "ocr_lang": request.app.state.config.DOCLING_OCR_LANG,
-                        "do_picture_description": request.app.state.config.DOCLING_DO_PICTURE_DESCRIPTION,
-                        "picture_description_mode": request.app.state.config.DOCLING_PICTURE_DESCRIPTION_MODE,
-                        "picture_description_local": request.app.state.config.DOCLING_PICTURE_DESCRIPTION_LOCAL,
-                        "picture_description_api": request.app.state.config.DOCLING_PICTURE_DESCRIPTION_API,
+                        "ocr_engine": "",
+                        "ocr_lang": "",
+                        "do_picture_description": False,
+                        "picture_description_mode": "",
+                        "picture_description_local": {},
+                        "picture_description_api": {},
                     },
-                    PDF_EXTRACT_IMAGES=request.app.state.config.PDF_EXTRACT_IMAGES,
+                    PDF_EXTRACT_IMAGES=False,
                     DOCUMENT_INTELLIGENCE_ENDPOINT=request.app.state.config.DOCUMENT_INTELLIGENCE_ENDPOINT,
                     DOCUMENT_INTELLIGENCE_KEY=request.app.state.config.DOCUMENT_INTELLIGENCE_KEY,
                     MISTRAL_OCR_API_KEY=request.app.state.config.MISTRAL_OCR_API_KEY,
@@ -1544,6 +1544,7 @@ async def process_file(
     size = (file.meta or {}).get("size", 0)
     threshold = request.app.state.config.FILE_ASYNC_THRESHOLD
     if threshold and size and size > threshold * 1024 * 1024:
+
         async def runner():
             try:
                 await asyncio.to_thread(_process_file_sync, request, form_data, user)
@@ -1557,6 +1558,7 @@ async def process_file(
         return {"status": True, "task_id": task_id}
     else:
         return await asyncio.to_thread(_process_file_sync, request, form_data, user)
+
 
 class ProcessTextForm(BaseModel):
     name: str


### PR DESCRIPTION
## Summary
- Remove optional DATALAB_MARKER flags and force them disabled in retrieval loader
- Default OCR-related configuration values to disabled in config

## Testing
- `python -m black backend/open_webui/routers/retrieval.py backend/open_webui/config.py`
- `PYTHONPATH=backend pytest` *(fails: ImportError: cannot import name 'MAX_RETRY_COUNT' from 'open_webui.utils.redis')*


------
https://chatgpt.com/codex/tasks/task_e_68acad591f6c83268ea75cd55039dc84