### PR TITLE
Increase embedding batch and chunk defaults, drop file upload limit

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -2281,11 +2281,7 @@ RAG_FILE_MAX_COUNT = PersistentConfig(
 RAG_FILE_MAX_SIZE = PersistentConfig(
     "RAG_FILE_MAX_SIZE",
     "rag.file.max_size",
-    (
-        int(os.environ.get("RAG_FILE_MAX_SIZE"))
-        if os.environ.get("RAG_FILE_MAX_SIZE")
-        else None
-    ),
+    None,
 )
 
 RAG_FILE_ASYNC_THRESHOLD = PersistentConfig(
@@ -2358,10 +2354,7 @@ RAG_EMBEDDING_MODEL_TRUST_REMOTE_CODE = (
 RAG_EMBEDDING_BATCH_SIZE = PersistentConfig(
     "RAG_EMBEDDING_BATCH_SIZE",
     "rag.embedding_batch_size",
-    int(
-        os.environ.get("RAG_EMBEDDING_BATCH_SIZE")
-        or os.environ.get("RAG_EMBEDDING_OPENAI_BATCH_SIZE", "32")
-    ),
+    int(os.environ.get("RAG_EMBEDDING_BATCH_SIZE", "256")),
 )
 
 RAG_EMBEDDING_QUERY_PREFIX = os.environ.get("RAG_EMBEDDING_QUERY_PREFIX", None)
@@ -2425,7 +2418,7 @@ TIKTOKEN_ENCODING_NAME = PersistentConfig(
 
 
 CHUNK_SIZE = PersistentConfig(
-    "CHUNK_SIZE", "rag.chunk_size", int(os.environ.get("CHUNK_SIZE", "2000"))
+    "CHUNK_SIZE", "rag.chunk_size", int(os.environ.get("CHUNK_SIZE", "5000"))
 )
 CHUNK_OVERLAP = PersistentConfig(
     "CHUNK_OVERLAP",

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -273,7 +273,7 @@ class EmbeddingModelUpdateForm(BaseModel):
     azure_openai_config: Optional[AzureOpenAIConfigForm] = None
     embedding_engine: str
     embedding_model: str
-    embedding_batch_size: Optional[int] = 32
+    embedding_batch_size: Optional[int] = 256
 
 
 @router.post("/embedding/update")
@@ -881,7 +881,9 @@ async def update_rag_config(
     )
 
     # File upload settings
-    request.app.state.config.FILE_MAX_SIZE = form_data.FILE_MAX_SIZE
+    request.app.state.config.FILE_MAX_SIZE = (
+        form_data.FILE_MAX_SIZE if form_data.FILE_MAX_SIZE not in (None, 0) else None
+    )
     request.app.state.config.FILE_MAX_COUNT = form_data.FILE_MAX_COUNT
     request.app.state.config.FILE_ASYNC_THRESHOLD = form_data.FILE_ASYNC_THRESHOLD
     request.app.state.config.FILE_IMAGE_COMPRESSION_WIDTH = (

--- a/src/lib/components/admin/Settings/Documents.svelte
+++ b/src/lib/components/admin/Settings/Documents.svelte
@@ -40,7 +40,7 @@
 
 	let embeddingEngine = '';
 	let embeddingModel = '';
-        let embeddingBatchSize = 32;
+        let embeddingBatchSize = 256;
 	let rerankingModel = '';
 
 	let OpenAIUrl = '';
@@ -222,7 +222,7 @@
 		if (embeddingConfig) {
 			embeddingEngine = embeddingConfig.embedding_engine;
 			embeddingModel = embeddingConfig.embedding_model;
-                        embeddingBatchSize = embeddingConfig.embedding_batch_size ?? 32;
+                        embeddingBatchSize = embeddingConfig.embedding_batch_size ?? 256;
 
 			OpenAIKey = embeddingConfig.openai_config.key;
 			OpenAIUrl = embeddingConfig.openai_config.url;
@@ -238,8 +238,9 @@
 	onMount(async () => {
 		await setEmbeddingConfig();
 
-		const config = await getRAGConfig(localStorage.token);
-		config.ALLOWED_FILE_EXTENSIONS = (config?.ALLOWED_FILE_EXTENSIONS ?? []).join(', ');
+                const config = await getRAGConfig(localStorage.token);
+                config.FILE_MAX_SIZE = config.FILE_MAX_SIZE ?? '';
+                config.ALLOWED_FILE_EXTENSIONS = (config?.ALLOWED_FILE_EXTENSIONS ?? []).join(', ');
 
 		config.DOCLING_PICTURE_DESCRIPTION_LOCAL = JSON.stringify(
 			config.DOCLING_PICTURE_DESCRIPTION_LOCAL ?? {},


### PR DESCRIPTION
## Summary
- Raise default embedding batch size to 256 and chunk size to 5000
- Remove file upload size limit and treat 0/None as unlimited
- Reflect changes in admin UI

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'open_webui')*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68acb36781248326924bc87dcb02e6e5