### PR TITLE
Allow unlimited document uploads

### DIFF
--- a/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
+++ b/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
@@ -145,21 +145,6 @@
 			return null;
 		}
 
-		if (
-			($config?.file?.max_size ?? null) !== null &&
-			file.size > ($config?.file?.max_size ?? 0) * 1024 * 1024
-		) {
-			console.log('File exceeds max size limit:', {
-				fileSize: file.size,
-				maxSize: ($config?.file?.max_size ?? 0) * 1024 * 1024
-			});
-			toast.error(
-				$i18n.t(`File size should not exceed {{maxSize}} MB.`, {
-					maxSize: $config?.file?.max_size
-				})
-			);
-			return;
-		}
 
 		knowledge.files = [...(knowledge.files ?? []), fileItem];
 

--- a/src/lib/components/workspace/Models/Knowledge.svelte
+++ b/src/lib/components/workspace/Models/Knowledge.svelte
@@ -103,21 +103,7 @@
 				extension: file.name.split('.').at(-1)
 			});
 
-			if (
-				($config?.file?.max_size ?? null) !== null &&
-				file.size > ($config?.file?.max_size ?? 0) * 1024 * 1024
-			) {
-				console.log('File exceeds max size limit:', {
-					fileSize: file.size,
-					maxSize: ($config?.file?.max_size ?? 0) * 1024 * 1024
-				});
-				toast.error(
-					$i18n.t(`File size should not exceed {{maxSize}} MB.`, {
-						maxSize: $config?.file?.max_size
-					})
-				);
-				return;
-			}
+                        
 
 			if (!file['type'].startsWith('image/')) {
 				uploadFileHandler(file);


### PR DESCRIPTION
## Summary
- remove file size check when uploading knowledge base documents
- drop size restriction for model knowledge uploads

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run test:frontend` *(fails: vitest not found)*
- `npm install` *(fails: dependency resolution conflict)*
- `npm install --force` *(fails: ENETUNREACH connect)*

------
https://chatgpt.com/codex/tasks/task_e_68acd442d0cc832692fc331cd93c3fd6