### PR TITLE
Fix chat interface spinner for new chats

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -93,7 +93,7 @@
 
 	export let chatIdProp = '';
 
-	let loading = true;
+let loading = !!chatIdProp;
 
 	const eventTarget = new EventTarget();
 	let controlPane;
@@ -457,30 +457,24 @@
 		}
 	};
 
-	let pageSubscribe = null;
-	onMount(async () => {
-		loading = true;
-		console.log('mounted');
-		window.addEventListener('message', onMessageHandler);
-		$socket?.on('chat-events', chatEventHandler);
+        let pageSubscribe = null;
+        onMount(async () => {
+                console.log('mounted');
+                window.addEventListener('message', onMessageHandler);
+                $socket?.on('chat-events', chatEventHandler);
 
-		pageSubscribe = page.subscribe(async (p) => {
-			if (p.url.pathname === '/') {
-				await tick();
-				initNewChat();
-			}
-		});
+                pageSubscribe = page.subscribe(async (p) => {
+                        if (p.url.pathname === '/') {
+                                await tick();
+                                initNewChat();
+                        }
+                });
 
-		const storageChatInput = sessionStorage.getItem(
-			`chat-input${chatIdProp ? `-${chatIdProp}` : ''}`
-		);
+                const storageChatInput = sessionStorage.getItem(
+                        `chat-input${chatIdProp ? `-${chatIdProp}` : ''}`
+                );
 
-		if (!chatIdProp) {
-			loading = false;
-			await tick();
-		}
-
-		if (storageChatInput) {
+                if (storageChatInput) {
 			prompt = '';
 			messageInput?.setText('');
 


### PR DESCRIPTION
## Summary
- initialize chat loading state based on the presence of a chat id so the interface doesn't get stuck on the spinner
- streamline `onMount` to avoid forcing a loading spinner for new chats

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run test:frontend` *(fails: `vitest: not found`)*
- `npm run lint:frontend` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68b1fe1694988326a10952724240a2ad